### PR TITLE
Add jiraServerUrl in arguments in upload method

### DIFF
--- a/lib/assertthat-bdd.rb
+++ b/lib/assertthat-bdd.rb
@@ -46,7 +46,7 @@ module AssertThatBDD
   end
   
   class Report
-    def self.upload(accessKey: ENV['ASSERTTHAT_ACCESS_KEY'], secretKey: ENV['ASSERTTHAT_ACCESS_KEY'], projectId: nil, runName: 'Test run '+Time.now.strftime("%d %b %Y %H:%M:%S"), jsonReportFolder: './reports', jsonReportIncludePattern: '.*.json'  )
+    def self.upload(accessKey: ENV['ASSERTTHAT_ACCESS_KEY'], secretKey: ENV['ASSERTTHAT_ACCESS_KEY'], projectId: nil, runName: 'Test run '+Time.now.strftime("%d %b %Y %H:%M:%S"), jsonReportFolder: './reports', jsonReportIncludePattern: '.*.json', jiraServerUrl: nil  )
 		url = "https://bdd.assertthat.app/rest/api/1/project/" + projectId + "/report"
 		url = jiraServerUrl+"/rest/assertthat/latest/project/"+projectId+"/client/report" unless jiraServerUrl.nil?
     	files = Find.find(jsonReportFolder).grep(/#{jsonReportIncludePattern}/)


### PR DESCRIPTION
In the absence of jiraServerUrl in arguments:
1. Upload method throw  "unknown keyword: jiraServerUrl (ArgumentError)" when passing jiraServerUrl option in upload method 
2. Throw "undefined local variable or method `jiraServerUrl' for AssertThatBDD::Report:Class (NameError)" on not passing jiraServerUrl option in upload method.